### PR TITLE
Bump bindgen to 0.68.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ libc = "0.2.102"
 
 [build-dependencies]
 cc = { version = "1.0.67", features = ["parallel"] }
-bindgen = "0.59.1"
+bindgen = "0.68.1"


### PR DESCRIPTION
This allows this crate to compile on the latest Rust (previously, bindgen tried to generate an invalid ident).